### PR TITLE
Change order of Babel plugins (fixes decorators)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
       "react-app"
     ],
     "plugins": [
-      "react-hot-loader/babel",
-      "transform-decorators-legacy"
+      "transform-decorators-legacy",
+      "react-hot-loader/babel"
     ]
   },
   "styleguide": {


### PR DESCRIPTION
Fixes support for decorated arrow methods.