### PR TITLE
Add tslint configuration compatible .prettierrc.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "bracketSpacing": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
Without .prettierrc Prettier editor (Atom in my case) integration didn't format the files same way as `prettier-tslint` did.